### PR TITLE
version bump to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "gulp": "3.8.11",
     "gulp-rev": "4.0.0",
     "gulp-rev-replace": "0.4.1",
-    "gulp-minify-css": "1.1.0",
+    "gulp-minify-css": "1.1.3",
     "gulp-uglify": "1.2.0",
     "gulp-filter": "2.0.2",
     "gulp-connect": "2.2.0",


### PR DESCRIPTION
minicss in gulpfile was corrected gulp-minify can now be safely upgraded.
